### PR TITLE
Fix camera discovery in installed builds and remove scary permission popup

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2244,6 +2244,8 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-updater",
+ "webview2-com",
+ "windows",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,3 +30,7 @@ tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+
+[target.'cfg(windows)'.dependencies]
+webview2-com = "0.38"
+windows = "0.61"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -418,10 +418,79 @@ mod tests {
     }
 }
 
+/// Answers WebView2 camera/microphone permission requests from the app's own
+/// origin so users never see the browser-style permission prompt. Windows'
+/// global camera/microphone privacy settings still apply.
+#[cfg(windows)]
+fn auto_allow_media_permissions(window: &tauri::WebviewWindow) {
+    use webview2_com::{
+        take_pwstr,
+        Microsoft::Web::WebView2::Win32::{
+            COREWEBVIEW2_PERMISSION_KIND_CAMERA, COREWEBVIEW2_PERMISSION_KIND_MICROPHONE,
+            COREWEBVIEW2_PERMISSION_STATE_ALLOW,
+        },
+        PermissionRequestedEventHandler,
+    };
+
+    let result = window.with_webview(|webview| unsafe {
+        let core = match webview.controller().CoreWebView2() {
+            Ok(core) => core,
+            Err(error) => {
+                eprintln!("auto_allow_media_permissions: no CoreWebView2: {error}");
+                return;
+            }
+        };
+
+        let handler = PermissionRequestedEventHandler::create(Box::new(|_sender, args| {
+            let Some(args) = args else {
+                return Ok(());
+            };
+
+            let mut uri = windows::core::PWSTR::null();
+            args.Uri(&mut uri)?;
+            let uri = take_pwstr(uri);
+            let own_origin = uri.starts_with("http://tauri.localhost")
+                || uri.starts_with("https://tauri.localhost")
+                || uri.starts_with("http://localhost:1420");
+
+            let mut kind = Default::default();
+            args.PermissionKind(&mut kind)?;
+
+            if own_origin
+                && (kind == COREWEBVIEW2_PERMISSION_KIND_CAMERA
+                    || kind == COREWEBVIEW2_PERMISSION_KIND_MICROPHONE)
+            {
+                args.SetState(COREWEBVIEW2_PERMISSION_STATE_ALLOW)?;
+            }
+
+            Ok(())
+        }));
+
+        let mut token = 0i64;
+        if let Err(error) = core.add_PermissionRequested(&handler, &mut token) {
+            eprintln!("auto_allow_media_permissions: could not register handler: {error}");
+        }
+    });
+
+    if let Err(error) = result {
+        eprintln!("auto_allow_media_permissions: with_webview failed: {error}");
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .manage(SharedRenderCache::default())
+        .setup(|app| {
+            #[cfg(windows)]
+            {
+                use tauri::Manager;
+                if let Some(window) = app.get_webview_window("main") {
+                    auto_allow_media_permissions(&window);
+                }
+            }
+            Ok(())
+        })
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_opener::init())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,11 +42,12 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' http://127.0.0.1:5000 http://localhost:5000 https://cdn.jsdelivr.net https://storage.googleapis.com https://github.com https://objects.githubusercontent.com https://api.github.com; worker-src 'self' blob:"
+      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' http://127.0.0.1:5000 http://localhost:5000 https://cdn.jsdelivr.net https://storage.googleapis.com https://github.com https://objects.githubusercontent.com https://api.github.com; worker-src 'self' blob:"
     }
   },
   "bundle": {
     "active": true,
+    "publisher": "3WB",
     "targets": ["nsis"],
     "createUpdaterArtifacts": true,
     "icon": [

--- a/src/lib/faceTracker.ts
+++ b/src/lib/faceTracker.ts
@@ -39,6 +39,7 @@ export class FaceTracker {
   private lastFrameAt = 0;
   private lastDetectionAt = 0;
   private onVideoStopped: (() => void) | undefined;
+  private permissionPrimeAttempted = false;
 
   async start(
     callbacks: FaceTrackerCallbacks,
@@ -166,12 +167,40 @@ export class FaceTracker {
     this.lastDetectionAt = 0;
   }
 
-  async listCameras(): Promise<CameraDevice[]> {
+  async listCameras(
+    options: { primePermission?: boolean } = {},
+  ): Promise<CameraDevice[]> {
     if (!navigator.mediaDevices?.enumerateDevices) {
       return [];
     }
 
-    const devices = await navigator.mediaDevices.enumerateDevices();
+    let devices = await navigator.mediaDevices.enumerateDevices();
+
+    // Until the origin has camera permission, Chromium only exposes
+    // placeholder devices with empty deviceIds. Prompt once so the real
+    // list becomes visible.
+    const onlyPlaceholders = devices
+      .filter((device) => device.kind === "videoinput")
+      .every((device) => !device.deviceId);
+
+    if (
+      options.primePermission &&
+      onlyPlaceholders &&
+      !this.permissionPrimeAttempted &&
+      navigator.mediaDevices.getUserMedia
+    ) {
+      this.permissionPrimeAttempted = true;
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: true,
+        });
+        stream.getTracks().forEach((track) => track.stop());
+        devices = await navigator.mediaDevices.enumerateDevices();
+      } catch {
+        // Permission denied or no camera; fall through with what we have.
+      }
+    }
+
     let cameraNumber = 1;
 
     return devices

--- a/src/main.ts
+++ b/src/main.ts
@@ -1044,14 +1044,14 @@ function populateExpressionSelect() {
 
 let cameraRefreshSequence = 0;
 
-async function refreshCameraList() {
+async function refreshCameraList(options: { primePermission?: boolean } = {}) {
   if (!cameraSelect) return;
 
   const refreshSequence = ++cameraRefreshSequence;
   const selectedDeviceId = cameraSelect.value;
 
   try {
-    const cameras = await faceTracker.listCameras();
+    const cameras = await faceTracker.listCameras(options);
     if (refreshSequence !== cameraRefreshSequence) return;
 
     cameraSelect.textContent = "";
@@ -2372,7 +2372,7 @@ function wireLibraryControls() {
         bringPopoverToFront(popover);
         makePopoverDraggable(popover);
         if (name === "camera") {
-          void refreshCameraList();
+          void refreshCameraList({ primePermission: true });
         }
       } else {
         popover.hidden = true;


### PR DESCRIPTION
## What

Three fixes that make webcam tracking actually work from a fresh Windows install:

1. **Camera permission priming.** Fresh installs run at a new origin (`http://tauri.localhost`) with no camera permission, so `enumerateDevices()` only returned anonymous placeholder devices. Opening the camera popover now primes permission with a throwaway `getUserMedia` call and re-enumerates, so the real camera list appears.
2. **CSP fix for MediaPipe.** Production builds enforce the CSP (dev does not), and `script-src` blocked the MediaPipe WASM loader from cdn.jsdelivr.net. This is why tracking failed with `[object Event]` in installed builds. Added cdn.jsdelivr.net to `script-src`.
3. **Auto-grant camera/mic in Rust.** Handle WebView2's `PermissionRequested` event and allow camera and microphone requests from the app's own origin, so users never see the browser-style permission prompt at all. Other permission kinds and other origins still use the default flow, and Windows' global privacy settings still apply.

Also sets the NSIS installer publisher to 3WB (was falling back to an unset value).

## Testing

Verified end-to-end on a real install: fresh WebView2 profile, opened camera popover, all four cameras listed with no popup, tracking started on first click.

Not a release: no version bump, no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)