### PR TITLE
Release v0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miituber",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miituber",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@mediapipe/tasks-vision": "^0.10.35",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "miituber",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "miituber"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miituber"
-version = "0.1.1"
+version = "0.1.2"
 description = "Turn your Mii into a VTuber avatar with webcam face tracking"
 authors = ["Mohammed Njie"]
 license = "AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "miituber",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.thedr.miituber",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Bump version to 0.1.2 across package.json, Cargo.toml, tauri.conf.json, and lockfiles. Includes the camera discovery fix and permission popup removal from #5.