### PR TITLE
Fix Tauri origin validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,6 @@ src-tauri/*.key*
 
 # Internal working files — kept locally, never published to the public repo
 AGENTS.md
-CLAUDE.md
-CLAUDE non fable.md
-MYTODO.md
 docs/
 .claude/
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ src-tauri/target
 src-tauri/*.key*
 
 # Internal working files — kept locally, never published to the public repo
+AGENTS.md
 CLAUDE.md
 CLAUDE non fable.md
 MYTODO.md

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -953,7 +953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2280,7 +2280,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3329,7 +3329,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3385,7 +3385,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3803,7 +3803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4057,9 +4057,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d059f2527558d9dba6f186dec4772610e1aecfd3f94002397613e7e648752b66"
+checksum = "b93bd86d231f0a8138f11a02a584769fe4b703dc36ae133d783228dbc4801405"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4419,7 +4419,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4776,7 +4776,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4805,7 +4805,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5238,7 +5238,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["macos-private-api"] }
+tauri = { version = "2.11.1", features = ["macos-private-api"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,16 @@
+#[cfg(any(windows, test))]
+fn is_trusted_media_origin(uri: &str) -> bool {
+    let Ok(uri) = tauri::Url::parse(uri) else {
+        return false;
+    };
+
+    match (uri.scheme(), uri.host_str(), uri.port()) {
+        ("http" | "https", Some("tauri.localhost"), None) => true,
+        ("http", Some("localhost"), Some(1420)) => true,
+        _ => false,
+    }
+}
+
 /// Answers WebView2 camera/microphone permission requests from the app's own
 /// origin so users never see the browser-style permission prompt. Windows'
 /// global camera/microphone privacy settings still apply.
@@ -29,9 +42,7 @@ fn auto_allow_media_permissions(window: &tauri::WebviewWindow) {
             let mut uri = windows::core::PWSTR::null();
             args.Uri(&mut uri)?;
             let uri = take_pwstr(uri);
-            let own_origin = uri.starts_with("http://tauri.localhost")
-                || uri.starts_with("https://tauri.localhost")
-                || uri.starts_with("http://localhost:1420");
+            let own_origin = is_trusted_media_origin(&uri);
 
             let mut kind = Default::default();
             args.PermissionKind(&mut kind)?;
@@ -77,4 +88,29 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_trusted_media_origin;
+
+    #[test]
+    fn trusts_app_and_development_origins() {
+        assert!(is_trusted_media_origin("http://tauri.localhost/"));
+        assert!(is_trusted_media_origin("https://tauri.localhost/camera"));
+        assert!(is_trusted_media_origin("http://localhost:1420/"));
+    }
+
+    #[test]
+    fn rejects_lookalike_and_untrusted_origins() {
+        assert!(!is_trusted_media_origin(
+            "http://tauri.localhost.attacker.example/"
+        ));
+        assert!(!is_trusted_media_origin(
+            "http://tauri.localhost@attacker.example/"
+        ));
+        assert!(!is_trusted_media_origin("https://localhost:1420/"));
+        assert!(!is_trusted_media_origin("http://localhost:1421/"));
+        assert!(!is_trusted_media_origin("not a URL"));
+    }
 }


### PR DESCRIPTION
Raise the Tauri security floor past CVE-2026-42184 and require exact origins before automatically granting camera or microphone access.

Refs #12